### PR TITLE
Potential fix for code scanning alert no. 62: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -69,12 +69,11 @@ public class CommentsCache {
       throws XMLStreamException, JAXBException {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
-
-    // TODO fix me disabled for now.
-    if (securityEnabled) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    // Securely configure the XMLInputFactory to prevent XXE
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Compliant
+    xif.setProperty("javax.xml.stream.isSupportingExternalEntities", Boolean.FALSE);
+    xif.setProperty("javax.xml.stream.supportDTD", Boolean.FALSE);
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/appsec2023/WebGoat/security/code-scanning/62](https://github.com/appsec2023/WebGoat/security/code-scanning/62)

The best way to fix the problem is to always securely configure the XML parser to disallow DTDs and external entity references unless there is a good reason to do otherwise. Specifically, for `XMLInputFactory`, set the required properties to prevent access to external DTDs and schemas, and disable entity expansion on the parser itself.

**Detailed fix:**
- Set the following on `XMLInputFactory` _regardless_ of the `securityEnabled` flag:
    - `XMLConstants.ACCESS_EXTERNAL_DTD` to `""`
    - `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to `""`
    - `"javax.xml.stream.isSupportingExternalEntities"` to `false`
    - `"javax.xml.stream.supportDTD"` to `false`  
- Remove logic or the use of `securityEnabled` to avoid any case where the parser could be insecurely configured.
- Alternatively, if the vulnerable path must remain for instructional purposes, explicitly document and name it as such, but production-safe code should always harden the parser before user-tainted XML is parsed.

**Implementation:**
- In `CommentsCache.java`, always set the above properties on the `XMLInputFactory` before parsing in `parseXml`.
- Update code so that secure configuration is not conditional.
- No external dependencies are required, only the standard Java/Jakarta libraries.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
