### PR TITLE
Potential fix for code scanning alert no. 10: Unsafe HTML constructed from library input

### DIFF
--- a/src/main/resources/webgoat/static/js/jquery_form/jquery.form.js
+++ b/src/main/resources/webgoat/static/js/jquery_form/jquery.form.js
@@ -562,7 +562,7 @@ $.fn.ajaxSubmit = function(options) {
                            // if using the $.param format that allows for multiple values with the same name
                            if($.isPlainObject(s.extraData[n]) && s.extraData[n].hasOwnProperty('name') && s.extraData[n].hasOwnProperty('value')) {
                                extraInputs.push(
-                               $('<input type="hidden" name="'+s.extraData[n].name+'">').val(s.extraData[n].value)
+                               $('<input type="hidden">').attr('name', s.extraData[n].name).val(s.extraData[n].value)
                                    .appendTo(form)[0]);
                            } else {
                                extraInputs.push(


### PR DESCRIPTION
Potential fix for [https://github.com/appsec2023/WebGoat/security/code-scanning/10](https://github.com/appsec2023/WebGoat/security/code-scanning/10)

To fix this problem, any user-supplied input (e.g., from `s.extraData[n].name`) must be safely escaped before being inserted into HTML as an attribute. The optimal fix is to ensure that the `name` attribute is HTML-escaped, which prevents the injection of arbitrary HTML or JavaScript. Alternatively, constructing the input element using jQuery's API and setting the attribute via `.attr('name', ...)` automatically escapes it. Modify line 565 so the HTML input element is not constructed via string concatenation, but by using jQuery to create the element and assign the `name` attribute safely. Only replace the line(s) that assemble the input element in this way.

Implementation requires:
- Changing ` $('<input type="hidden" name="'+s.extraData[n].name+'">')` to ` $('<input type="hidden">').attr('name', s.extraData[n].name)`, ensuring jQuery safely handles the attribute.
- No external dependencies are needed.
- No changes are required outside this block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
